### PR TITLE
[RFC] chore: exclude stdout output by filename instead of Python bin

### DIFF
--- a/src/main/java/com/example/rpl/RPL/service/TestService.java
+++ b/src/main/java/com/example/rpl/RPL/service/TestService.java
@@ -118,7 +118,7 @@ public class TestService {
             } else if (line.contains("start_RUN")) {
                 result = new StringBuilder();
             } else if (line.contains("assignment_main.py") || line.contains("./main") || line
-                .contains("/usr/bin/python3.7")) {
+                .contains("custom_IO_main.pyc")) {
                 continue;
             } else {
                 result.append(line).append("\n");

--- a/src/test/groovy/com/example/rpl/RPL/controller/CoursesControllerFunctionalSpec.groovy
+++ b/src/test/groovy/com/example/rpl/RPL/controller/CoursesControllerFunctionalSpec.groovy
@@ -487,7 +487,7 @@ class CoursesControllerFunctionalSpec extends AbstractFunctionalSpec {
             def loginResponse = getJsonResponse(post("/api/auth/login", body))
 
         when:
-            def response = post(String.format("/api/courses/%s/enroll", 22), [], [
+            def response = post(String.format("/api/courses/%s/enroll", 20000), [], [
                     "Authorization": String.format("%s %s", loginResponse.token_type, loginResponse.access_token)
             ])
 
@@ -526,7 +526,7 @@ class CoursesControllerFunctionalSpec extends AbstractFunctionalSpec {
             def loginResponse = getJsonResponse(post("/api/auth/login", body))
 
         when:
-            def response = post(String.format("/api/courses/%s/unenroll", 22), [], [
+            def response = post(String.format("/api/courses/%s/unenroll", 20000), [], [
                     "Authorization": String.format("%s %s", loginResponse.token_type, loginResponse.access_token)
             ])
 


### PR DESCRIPTION
La línea marcada busca eliminar la salida de `/usr/bin/python3.7 custom_IO_main.pyc` en los tests de IO para actividades de Python (de, actualmente, [este comando de make](https://github.com/reinvent-fiuba/RPL-2.0-runner/blob/89610e1ce62051ea8e9fa0b58251f7aa3b753995/rpl_runner/python_Makefile#L13)).

Esto lo hace buscando la cadena `"/usr/bin/python3.7"` dentro de la línea, pero impide posibles cambios de versiones de Python. Por esto se cambia el filtro para considerar `"custom_IO_main.pyc"`