### PR TITLE
Updated GH actions plugins

### DIFF
--- a/.github/workflows/google.yml
+++ b/.github/workflows/google.yml
@@ -37,18 +37,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       
       - name: Replace New Relic Licence code
         run: sed -i "s|NEW_RELIC_LICENSE_KEY|$NEW_RELIC_LICENSE_KEY|" ./newrelic/newrelic.yml
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 11
+          distribution: 'zulu'
 
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
@@ -61,11 +62,11 @@ jobs:
         run: ./gradlew build
 
       # Setup gcloud CLI
-      - uses: google-github-actions/auth@v0
+      - uses: google-github-actions/auth@v2
         with:
           credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
 
-      - uses: 'google-github-actions/get-gke-credentials@v1'
+      - uses: 'google-github-actions/get-gke-credentials@v2'
         with:
           cluster_name: ${{ env.GKE_CLUSTER }}
           location: ${{ env.GKE_ZONE }}


### PR DESCRIPTION
`actions/checkout@v2` y `google-github-actions/auth@v0` estaban deprecados